### PR TITLE
Updating exec sponsor per request from the TPM org

### DIFF
--- a/ownership.yaml
+++ b/ownership.yaml
@@ -10,8 +10,8 @@ ownership:
     kind: logical
     maintainer: johanrosenkilde
     team: github/next
-    exec_sponsor: kdaigle
-    product_manager: mattrothenberg
+    exec_sponsor: lostintangent
+    product_manager: johanrosenkilde
     repo: https://github.com/githubnext/copilot-cli
     sev3:
       slack: next-copilot-cli


### PR DESCRIPTION
All services in the service catalog need to have an exec sponsor, and so I'm just marking myself as that for now, so that Kyle doesn't get unnecessary pings/etc.