### PR TITLE
Fix typo in feature request template description

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -14,7 +14,7 @@ body:
     id: title
     attributes:
       label: Describe the feature or problem you'd like to solve
-      description: A clear and concise description of what the feature or porblem is.
+      description: A clear and concise description of what the feature or problem is.
   - type: textarea
     id: description
     attributes:


### PR DESCRIPTION
This pull request fixes a typo in the feature request issue template, correcting "porblem" to "problem" in the description field.