### PR TITLE
Add workflow to automatically submit to Winget

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,44 @@
+name: Submit release to the WinGet community repository
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-winget:
+    name: Submit to WinGet repository
+
+    # GitHub token permissions needed for winget-create to submit a PR
+    permissions:
+      contents: read
+      pull-requests: write
+
+    # winget-create is only supported on Windows
+    runs-on: windows-latest
+      
+    # winget-create will read the following environment variable to access the GitHub token needed for submitting a PR
+    # See https://aka.ms/winget-create-token
+    env:
+      WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
+
+    steps:
+      - name: Submit package using wingetcreate
+        run: |
+          # Set the package ID based on the release info
+          $packageId = if (${{ !github.event.release.prerelease }}) { "GitHub.Copilot" } else { "GitHub.Copilot.Prerelease" }
+          
+          # Get installer info from release event
+          $assets = '${{ toJSON(github.event.release.assets) }}' | ConvertFrom-Json
+          $packageVersion = (${{ toJSON(github.event.release.tag_name) }})
+          
+          # Find the download URLs for the x64 and arm64 installers separately
+          # This allows overrides to be used so that wingetcreate does not have to guess the architecture from the filename
+          $installerUrlx64 = $assets | Where-Object -Property name -like '*win32-x64.zip' | Select-Object -ExpandProperty browser_download_url
+          $installerUrlarm64 = $assets | Where-Object -Property name -like '*win32-arm64.zip' | Select-Object -ExpandProperty browser_download_url
+          
+          # Update package using wingetcreate
+          curl.exe -JLO https://aka.ms/wingetcreate/latest
+          .\wingetcreate.exe update $packageId `
+            --version $packageVersion `
+            --urls "$installerUrlx64|x64" "$installerUrlarm64|arm64" `
+            --submit


### PR DESCRIPTION
<!-- Links -->
[ms-cla]: https://cla.opensource.microsoft.com
<!-- End of Links -->

## 📖 Description
PR adds a GitHub action workflow for submitting the release to winget-pkgs repository. 

### GitHub Repository Secret
To add a personal access token (PAT), one can follow the steps listed in https://github.com/microsoft/winget-create?tab=readme-ov-file#github-personal-access-token-classic-permissions. Before this PR is merged, maintainers will need to create a repository secret with the name `WINGET_CREATE_GITHUB_TOKEN`.

## 🔗 References and Related Issues
- Resolves #702 
- Related to microsoft/winget-pkgs#319781
- Related to microsoft/winget-pkgs#319779

See similar actions in the following repositories

- https://github.com/microsoft/winget-studio/blob/main/.github/workflows/winget.yml
- https://github.com/microsoft/edit/blob/main/.github/workflows/winget.yml
- https://github.com/microsoft/terminal/blob/main/.github/workflows/winget.yml
- https://github.com/microsoft/PowerToys/blob/main/.github/workflows/package-submissions.yml

## 🔍 How to Test
Action is tricky to test without a fork, but I've tested similar actions in private forks previously. One can test the wingetcreate command by omitting the --submit flag to see if the command will succeed

As a side note - if the workflow starts randomly failing, it is likely that whichever fork of winget-pkgs the repository secret is giving access to is outdated and needs to be synced with the upstream due to a bug in Octokit

## ✅ Checklist
- [x] Have you signed the [Contributor License Agreement][ms-cla]?
- [x] Is there a linked Issue?
- [ ] Documentation updated?