### PR TITLE
Add WinGet command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you have access to GitHub Copilot via your organization or enterprise, you ca
 
 ### Installation
 
-    Install globally with npm:
+Install globally with npm:
 
 ```bash
 npm install -g @github/copilot


### PR DESCRIPTION
<!-- Links -->
[ms-cla]: https://cla.opensource.microsoft.com
<!-- End of Links -->

## 📖 Description
Updates the README to inform users about the availability of using WinGet to install GitHub Copilot 

## 🔗 References and Related Issues
- Related to  #702 

## 🔍 How to Test
Wait for microsoft/winget-pkgs#319781 to have the `Publish-Pipeline-Succeeded` label. Then, run `winget search GitHub.Copilot`. As long as the results show `GitHub.Copilot` as available, the package will be available to be installed via WinGet

## ✅ Checklist
- [x] Have you signed the [Contributor License Agreement][ms-cla]?
- [x] Is there a linked Issue?
- [x] Documentation updated?

###### cc @denelon