### PR TITLE
add Homebrew install to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Install with [WinGet](https://github.com/microsoft/winget-cli):
 winget install GitHub.Copilot
 ```
 
+Install with [Homebrew](https://brew.sh/):
+
+```bash
+brew install copilot-cli
+```
+
 ### Launching the CLI
 
 ```bash


### PR DESCRIPTION
Hi - one of the Homebrew maintainers here 👋 

Add Homebrew installation instructions to the README, now that we're providing this via Homebrew Casks.

Closes https://github.com/github/copilot-cli/issues/739

Thanks!