### PR TITLE
feat: add repo-mind index workflow for wiki generation

### DIFF
--- a/.github/workflows/repo-mind-index.yml
+++ b/.github/workflows/repo-mind-index.yml
@@ -1,0 +1,209 @@
+name: Repo-mind Index
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+  packages: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  update-index:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify repo-mind access secrets
+        run: |
+          set -euo pipefail
+          if [ -z "${{ secrets.REPO_MIND_GHCR_USERNAME }}" ]; then
+            echo "Missing required secret REPO_MIND_GHCR_USERNAME" >&2
+            exit 1
+          fi
+          if [ -z "${{ secrets.REPO_MIND_GHCR_TOKEN }}" ]; then
+            echo "Missing required secret REPO_MIND_GHCR_TOKEN" >&2
+            exit 1
+          fi
+
+      - name: Seed cache from committed index
+        run: |
+          set -euo pipefail
+          mkdir -p .cache/blobs
+          if [ -d repo-mind-index ] && [ "$(ls -A repo-mind-index)" ]; then
+            rsync -a repo-mind-index/ .cache/blobs/
+          fi
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.REPO_MIND_GHCR_USERNAME }}
+          password: ${{ secrets.REPO_MIND_GHCR_TOKEN }}
+
+      - name: Pull repo-mind image
+        run: docker pull ghcr.io/githubnext/repo-mind:latest
+
+      - name: Run repo-mind indexer
+        env:
+          GITHUB_TOKEN: ${{ secrets.REPO_MIND_GHCR_TOKEN }}
+          GITHUBNEXT_MODEL_8_UKSOUTH_API_KEY: ${{ secrets.GITHUBNEXT_MODEL_8_UKSOUTH_API_KEY }}
+          GITHUBNEXT_EASTUS2_API_KEY: ${{ secrets.GITHUBNEXT_EASTUS2_API_KEY }}
+        run: |
+          set -euo pipefail
+          repo_mind_output_file="${PWD}/.repo_mind_output.json"
+          : > "${repo_mind_output_file}"
+          chmod 666 "${repo_mind_output_file}"
+          docker run --rm \
+            -v "${PWD}":/github/workspace \
+            -v "${PWD}/repo-mind-config/common.yaml":/opt/repo-mind-action/configs/common.yaml:ro \
+            -v "${repo_mind_output_file}":/github/workspace/.repo_mind_output.json \
+            -e REPO_MIND_OP=index \
+            -e GITHUB_REPOSITORY="${{ github.repository }}" \
+            -e GITHUB_SHA="${{ github.sha }}" \
+            -e REPO_MIND_MAX_INDEX_AGE_IN_DAYS=0 \
+            -e GITHUB_TOKEN \
+            -e GITHUBNEXT_MODEL_8_UKSOUTH_API_KEY \
+            -e GITHUBNEXT_EASTUS2_API_KEY \
+            -e REPO_MIND_OUTPUT_FILE=/github/workspace/.repo_mind_output.json \
+            ghcr.io/githubnext/repo-mind:latest
+
+          rm -f "${repo_mind_output_file}"
+
+      - name: Fix blob permissions
+        run: |
+          set -euo pipefail
+          if [ -d .cache/blobs ]; then
+            sudo chown -R $USER:$USER .cache/blobs || true
+            chmod -R 755 .cache/blobs || true
+          fi
+
+      - name: Sync generated index into repo
+        run: |
+          set -euo pipefail
+
+          if [ ! -d ".cache/blobs" ]; then
+            echo "repo-mind did not produce .cache/blobs" >&2
+            exit 1
+          fi
+
+          rm -rf repo-mind-index
+          mkdir -p repo-mind-index
+          rsync -a --delete .cache/blobs/ repo-mind-index/
+
+      - name: Check out repo-mind sources
+        uses: actions/checkout@v4
+        with:
+          repository: githubnext/repo-mind
+          ref: copilot/refactor-rate-limit-handling
+          path: repo-mind-src
+          token: ${{ secrets.REPO_MIND_GHCR_TOKEN }}
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Prepare repo-mind configuration for wiki
+        run: |
+          set -euo pipefail
+          cp repo-mind-config/wiki-common.yaml repo-mind-src/configs/wiki-common.yaml
+          cp repo-mind-config/wiki.yaml repo-mind-src/configs/w3k-ci.yaml
+
+      - name: Generate repo wiki content
+        env:
+          PYTHONPATH: ${{ github.workspace }}/repo-mind-src
+          REPO_MIND_WORKDIR: ${{ github.workspace }}
+          GITHUB_TOKEN: ${{ secrets.REPO_MIND_GHCR_TOKEN }}
+          GITHUBNEXT_MODEL_8_UKSOUTH_API_KEY: ${{ secrets.GITHUBNEXT_MODEL_8_UKSOUTH_API_KEY }}
+          GITHUBNEXT_EASTUS2_API_KEY: ${{ secrets.GITHUBNEXT_EASTUS2_API_KEY }}
+          REPO_MIND_LOCAL_CACHE_DIR: ${{ github.workspace }}/.cache/blobs
+        run: |
+          set -euo pipefail
+          uv run --directory repo-mind-src python repo-mind/generate_wiki.py --config-name=w3k-ci
+
+      - name: Sync generated wiki into repo
+        run: |
+          set -euo pipefail
+          org=${GITHUB_REPOSITORY%%/*}
+          repo=${GITHUB_REPOSITORY#*/}
+          wiki_source="repo-mind-src/.cache/wiki/${org}/${repo}/_edited"
+          if [ ! -d "${wiki_source}" ]; then
+            echo "repo-mind wiki output not found at ${wiki_source}" >&2
+            exit 1
+          fi
+
+          rm -rf repo-wiki
+          mkdir -p repo-wiki
+          rsync -a --delete "${wiki_source}/" repo-wiki/
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Generate templated documentation
+        env:
+          REPO_MIND_SRC: ${{ github.workspace }}/repo-mind-src
+          REPO_MIND_WORKDIR: ${{ github.workspace }}
+          PYTHONPATH: ${{ github.workspace }}/repo-mind-src
+          GITHUB_TOKEN: ${{ secrets.REPO_MIND_GHCR_TOKEN }}
+          GITHUBNEXT_MODEL_8_UKSOUTH_API_KEY: ${{ secrets.GITHUBNEXT_MODEL_8_UKSOUTH_API_KEY }}
+          GITHUBNEXT_EASTUS2_API_KEY: ${{ secrets.GITHUBNEXT_EASTUS2_API_KEY }}
+          REPO_MIND_LOCAL_CACHE_DIR: ${{ github.workspace }}/.cache/blobs
+        run: |
+          set -euo pipefail
+          if [ -f "scripts/generate-docs.ts" ]; then
+            echo "Generating documentation from templates..."
+            bun run scripts/generate-docs.ts
+          else
+            echo "No generate-docs.ts script found, skipping template generation"
+          fi
+
+      - name: Prepare git state
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Publish wiki
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_ACTOR: github-actions[bot]
+        run: |
+          set -euo pipefail
+          if [ -f "scripts/publish-wiki.ts" ]; then
+            echo "Publishing wiki content..."
+            bun run scripts/publish-wiki.ts
+          else
+            echo "No publish-wiki.ts script found, skipping wiki publish"
+          fi
+
+      - name: Create pull request with refreshed index
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: chore/repo-mind-index-${{ github.run_id }}
+          title: 'chore: refresh repo-mind index'
+          commit-message: 'chore: refresh repo-mind index'
+          body: |
+            Automated Repo-mind indexing run triggered by `${{ github.sha }}`.
+
+            - Workflow: `${{ github.workflow }}`
+            - Run: `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
+
+            Please review the generated shards and merge if they look good.
+          add-paths: |
+            repo-mind-index/**
+            repo-wiki/**
+            docs/repo-wiki/**
+          delete-branch: true

--- a/repo-mind-config/common.yaml
+++ b/repo-mind-config/common.yaml
@@ -1,0 +1,121 @@
+description: "common config for generic repo"
+version: 0.9
+
+input:
+  default:
+    path: ${oc.env:REPO_MIND_WORKDIR,/github/workspace}
+    repo:
+      slug: ${oc.env:GITHUB_REPOSITORY,githubnext/w3k}
+      sha: ${oc.env:GITHUB_SHA,null}
+    code:
+      include_patterns:
+        - "**/*.py"
+        - "**/*.ts"
+        - "**/*.tsx"
+        - "**/*.js"
+        - "**/*.go"
+        - "**/*.rb"
+        - "**/*.cpp"
+        - "**/*.cc"
+        - "**/*.cxx"
+        - "**/*.hpp"
+        - "**/*.h"
+        - "**/*.hh"
+        - "**/*.hxx"
+      exclude_patterns:
+        - "**/node_modules/**"
+        - "**/.git/**"
+        - "**/dist/**"
+        - "**/build/**"
+        - "**/__pycache__/**"
+        - "**/venv/**"
+        - "**/env/**"
+    code_docs:
+      include_patterns:
+        - "**/*.md"
+        - "**/*.txt"
+        - "**/*.rst"
+        - "**/Dockerfile*"
+      exclude_patterns:
+        - "LICENSE"
+        - "ACKNOWLEDGEMENTS"
+        - "CONTRIBUTING"
+        - "CODE_OF_CONDUCT"
+        - "SECURITY"
+        - "CHANGELOG"
+        - "HISTORY"
+        - "CITATION"
+        - "MANIFEST.in"
+        - "**/node_modules/**"
+        - "**/.git/**"
+        - "**/dist/**"
+        - "**/build/**"
+        - "**/__pycache__/**"
+        - "**/venv/**"
+        - "**/env/**"
+    docs:
+      issue:
+        state: closed
+        allow_bot_origin: false
+      pr:
+        state: merged
+        allow_bot_origin: false
+
+index:
+  code:
+    generate_ast: true
+    generate_code_embeddings: true
+    generate_code_summary: true
+    generate_graphrag: true
+    chunk_size: 8000
+    chunk_overlap: 200
+  code_docs:
+    generate_code_doc_embeddings: true
+    generate_graphrag: true
+    chunk_size: 1000
+    chunk_overlap: 100
+  docs:
+    generate_doc_issue_embeddings: true
+    generate_doc_pr_embeddings: true
+    generate_graphrag: true
+    chunk_size: 1000
+    chunk_overlap: 100
+  graphrag:
+    generate_summaries_at_index: false
+    max_cluster_size: 10
+    knn_doc_to_graph: 5
+
+processing:
+  generate_model_id: "next-gpt-4.1-long-context"
+  summarization_model_id: "next-gpt-4.1"
+  embedding_model_id: "next-text-embedding-3-small-2"
+  parallelism: 32
+  update_if_exists: true
+  use_content_filter: true
+
+storage:
+  kind: azure
+  namespace: "v0.2.0/dev"
+
+query:
+  generate_answer: true
+  top_k: 20
+  use_code: true
+  use_code_summary: true
+  use_code_doc: true
+  use_doc: true
+  use_graphrag: true
+  structured_response_format: true
+  rewrite_query_flag: true
+
+debug:
+  print_every: 50
+  usage_tracking: false
+  disable_index_storage: false
+  force_from_scratch_indexing: false
+
+evaluation:
+  evaluation_model_id: "next-o3"
+
+defaults:
+  - query_graphrag_zero

--- a/repo-mind-config/wiki-common.yaml
+++ b/repo-mind-config/wiki-common.yaml
@@ -1,0 +1,116 @@
+description: "common config for wiki generation (older repo-mind source version)"
+version: 0.9
+
+input:
+  default:
+    path: ${oc.env:REPO_MIND_WORKDIR,/github/workspace}
+    repo:
+      slug: ${oc.env:GITHUB_REPOSITORY,githubnext/w3k}
+      sha: ${oc.env:GITHUB_SHA,null}
+    code:
+      include_patterns:
+        - "**/*.py"
+        - "**/*.ts"
+        - "**/*.tsx"
+        - "**/*.js"
+        - "**/*.go"
+        - "**/*.rb"
+        - "**/*.cpp"
+        - "**/*.cc"
+        - "**/*.cxx"
+        - "**/*.hpp"
+        - "**/*.h"
+        - "**/*.hh"
+        - "**/*.hxx"
+      exclude_patterns:
+        - "**/node_modules/**"
+        - "**/.git/**"
+        - "**/dist/**"
+        - "**/build/**"
+        - "**/__pycache__/**"
+        - "**/venv/**"
+        - "**/env/**"
+    code_docs:
+      include_patterns:
+        - "**/*.md"
+        - "**/*.txt"
+        - "**/*.rst"
+        - "**/Dockerfile*"
+      exclude_patterns:
+        - "LICENSE"
+        - "ACKNOWLEDGEMENTS"
+        - "CONTRIBUTING"
+        - "CODE_OF_CONDUCT"
+        - "SECURITY"
+        - "CHANGELOG"
+        - "HISTORY"
+        - "CITATION"
+        - "MANIFEST.in"
+        - "**/node_modules/**"
+        - "**/.git/**"
+        - "**/dist/**"
+        - "**/build/**"
+        - "**/__pycache__/**"
+        - "**/venv/**"
+        - "**/env/**"
+    docs:
+      issue:
+        state: closed
+        allow_bot_origin: false
+      pr:
+        state: merged
+        allow_bot_origin: false
+
+index:
+  code:
+    generate_ast: true
+    generate_code_embeddings: true
+    generate_code_summary: true
+    generate_graphrag: true
+    chunk_size: 8000
+  code_docs:
+    generate_code_doc_embeddings: true
+    generate_graphrag: true
+    chunk_size: 1000
+  docs:
+    generate_doc_issue_embeddings: true
+    generate_doc_pr_embeddings: true
+    generate_graphrag: true
+    chunk_size: 1000
+  graphrag:
+    generate_summaries_at_index: false
+    max_cluster_size: 10
+
+processing:
+  generate_model_id: "next-gpt-4.1-long-context"
+  summarization_model_id: "next-gpt-4.1"
+  embedding_model_id: "next-text-embedding-3-small-2"
+  parallelism: 32
+  update_if_exists: true
+  use_content_filter: true
+
+storage:
+  kind: azure
+  namespace: "v0.2.0/dev"
+
+query:
+  generate_answer: true
+  top_k: 20
+  use_code: true
+  use_code_summary: true
+  use_code_doc: true
+  use_doc: true
+  use_graphrag: true
+  structured_response_format: true
+
+debug:
+  print_every: 50
+  usage_tracking: false
+  disable_index_storage: false
+  force_from_scratch_indexing: false
+
+evaluation:
+  evaluation_model_id: "next-o3"
+
+defaults:
+  - query_graphrag_zero

--- a/repo-mind-config/wiki.yaml
+++ b/repo-mind-config/wiki.yaml
@@ -1,0 +1,10 @@
+defaults:
+  - wiki-common
+  - _self_
+
+storage:
+  kind: local
+  namespace: v0.2.0/dev
+
+debug:
+  force_from_scratch_indexing: false


### PR DESCRIPTION
## Summary
- Copies repo-mind-index.yml workflow from w3k repo
- Adds repo-mind-config directory with common.yaml, wiki-common.yaml, and wiki.yaml
- Enables automated wiki generation and repo indexing on pushes to main

## Notes
This workflow requires the following secrets to be configured:
- `REPO_MIND_GHCR_USERNAME`
- `REPO_MIND_GHCR_TOKEN`
- `GITHUBNEXT_MODEL_8_UKSOUTH_API_KEY`
- `GITHUBNEXT_EASTUS2_API_KEY`

The workflow will:
1. Index the codebase using repo-mind
2. Generate wiki content
3. Create automated PRs with refreshed index and wiki content

## Test plan
- [ ] Verify secrets are configured in the repo
- [ ] Manually trigger workflow via workflow_dispatch to test
- [ ] Review generated wiki content in PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)