### PR TITLE
Use string comparison to check the result of variable expansion

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Submit package using wingetcreate
         run: |
           # Set the package ID based on the release info
-          $packageId = if (${{ !github.event.release.prerelease }}) { "GitHub.Copilot" } else { "GitHub.Copilot.Prerelease" }
+          $packageId = if ('${{ !github.event.release.prerelease }}' -eq 'true') { 'GitHub.Copilot' } else { 'GitHub.Copilot.Prerelease' }
           
           # Get installer info from release event
           $assets = '${{ toJSON(github.event.release.assets) }}' | ConvertFrom-Json


### PR DESCRIPTION
This PR updates the conditional to properly check the prerelease property. Because GitHub Actions expands the variable as a string (`true`) and not the boolean that PowerShell expects (`$true`), a simple string comparison should ensure the releases go into the correct WinGet Identifier