### PR TITLE
chore(docs): add missing prefix to brew command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ winget install GitHub.Copilot.Prerelease
 Install with [Homebrew](https://formulae.brew.sh/cask/copilot-cli) (macOS and Linux):
 
 ```bash
-brew install copilot-cli
+brew install --cask copilot-cli
 ```
 
 ```bash
-brew install copilot-cli@prerelease
+brew install --cask copilot-cli
 ```
 
 Install with [npm](https://www.npmjs.com/package/@github/copilot) (macOS, Linux, and Windows):


### PR DESCRIPTION
The README is has a typo in the instructions for installation via `brew` which was merged last [month](https://github.com/github/copilot-cli/pull/740):

```
brew install copilot-cli
```
It is trying to install a non-existent _formula_ [`copilot-cli`](https://formulae.brew.sh/formula/copilot-cli) (404) instead of via _cask_ [`copilot-cli`](https://formulae.brew.sh/cask/copilot-cli):
```
Warning: No available formula with the name "copilot-cli". Did you mean copilot?
==> Searching for similarly named formulae and casks...
==> Formulae
copilot

To install copilot, run:
  brew install copilot

==> Casks
copilot-for-xcode

To install copilot-for-xcode, run:
```

~This PR fixes that~. Actually, I take that back.

Running the fix: `brew install --cask copilot-cli` added in my PR doesn't work on my machine (macOS Sequoia 15.6):
```
 brew install --cask copilot-cli
Warning: Cask 'copilot-cli' is unavailable: No Cask with this name exists.
==> Searching for similarly named casks...
==> Casks
copilot-for-xcode

To install copilot-for-xcode, run:
  brew install --cask copilot-for-xcode
```

Had to go with `pnpm i -g @github/copilot` for the time being.