### PR TITLE
Fix misleading doc - 0x models dont reduce quota

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Launch `copilot` in a folder that contains code you want to work with.
 
 By default, `copilot` utilizes Claude Sonnet 4.5. Run the `/model` slash command to choose from other available models, including Claude Sonnet 4 and GPT-5.
 
-Each time you submit a prompt to GitHub Copilot CLI, your monthly quota of premium requests is reduced by one. For information about premium requests, see [About premium requests](https://docs.github.com/copilot/managing-copilot/monitoring-usage-and-entitlements/about-premium-requests).
+Each time you submit a prompt to GitHub Copilot CLI using a model, your monthly quota of premium requests is reduced by the model's multiplier (e.g., 1x, 3x). Using a 0x model does not reduce your premium request quota. For information about premium requests, see [About premium requests](https://docs.github.com/copilot/managing-copilot/monitoring-usage-and-entitlements/about-premium-requests).
 
 For more information about how to use the GitHub Copilot CLI, see [our official documentation](https://docs.github.com/copilot/concepts/agents/about-copilot-cli).
 


### PR DESCRIPTION
The readme implies that the quota will be reduced by 1x even when we use a 0x model.

However, based on my practical use, 0x models don't reduce quota for every use.

Merging this PR will fix the misleading doc.

## Screenshots

Model - GPT 4.1 (0x)

1. At one point, the remaining quota is `90.4%`
<img width="1906" height="968" alt="s1" src="https://github.com/user-attachments/assets/41bdf88e-e74c-4d54-aa06-ac9609a459fa" />

2. After the request was fired, the quota is still `90.4%`
<img width="1902" height="925" alt="s2" src="https://github.com/user-attachments/assets/75b0f422-3ff8-4a25-ba64-44e842cf1298" />


