### PR TITLE
docs: Add LSP server configuration guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,64 @@ Each time you submit a prompt to GitHub Copilot CLI, your monthly quota of premi
 
 For more information about how to use the GitHub Copilot CLI, see [our official documentation](https://docs.github.com/copilot/concepts/agents/about-copilot-cli).
 
+## 🔧 Configuring LSP Servers
+
+GitHub Copilot CLI supports Language Server Protocol (LSP) for enhanced code intelligence. This feature is currently experimental and provides intelligent code features like go-to-definition, hover information, and diagnostics.
+
+### Enabling LSP Support
+
+To use LSP features, you must enable experimental mode:
+
+```bash
+copilot --experimental
+```
+
+Or use the `/experimental` command within an interactive session.
+
+### Installing Language Servers
+
+Copilot CLI does not bundle LSP servers. You need to install them separately. For example, to set up TypeScript support:
+
+```bash
+npm install -g typescript-language-server
+```
+
+For other languages, install the corresponding LSP server and configure it following the same pattern shown below.
+
+### Configuring LSP Servers
+
+LSP servers are configured through a dedicated LSP configuration file. You can configure LSP servers at the user level or repository level:
+
+**User-level configuration** (applies to all projects):
+Edit `~/.copilot/lsp-config.json`
+
+**Repository-level configuration** (applies to specific project):
+Create `.github/lsp.json` in your repository root
+
+Example configuration:
+
+```json
+{
+  "lspServers": {
+    "typescript": {
+      "command": "typescript-language-server",
+      "args": ["--stdio"],
+      "disabled": false,
+      "fileExtensions": {
+        ".ts": "typescript",
+        ".tsx": "typescript"
+      }
+    }
+  }
+}
+```
+
+### Viewing LSP Server Status
+
+Check configured LSP servers using the `/lsp` command in an interactive session, or view your configuration files directly.
+
+For more information, see the [changelog](./changelog.md).
+
 ## 📢 Feedback and Participation
 
 We're excited to have you join us early in the Copilot CLI journey.


### PR DESCRIPTION
This PR adds documentation for configuring LSP servers in GitHub Copilot CLI.

## Changes
- Added new section '🔧 Configuring LSP Servers' to README
- Documented how to enable experimental LSP support
- Included TypeScript language server installation example
- Provided configuration examples for ~/.copilot/lsp-config.json and .github/lsp.json
- Added instructions for viewing LSP server status

## Configuration Example
The documentation includes a complete TypeScript LSP server configuration with:
- Command and args setup
- File extension mappings (.ts, .tsx)
- User-level and repository-level configuration options