### PR TITLE
docs: add experimental mode section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Once activated, the setting is persisted in your config, so the `--experimental`
 
 #### Experimental Features
 
-- **Autopilot mode:** Press `Shift+Tab` to toggle autopilot mode, which encourages the agent to continue working until a task is completed.
+- **Autopilot mode:** Autopilot is a new mode (press `Shift+Tab` to cycle through modes), which encourages the agent to continue working until a task is completed.
 
 Each time you submit a prompt to GitHub Copilot CLI, your monthly quota of premium requests is reduced by one. For information about premium requests, see [About premium requests](https://docs.github.com/copilot/managing-copilot/monitoring-usage-and-entitlements/about-premium-requests).
 


### PR DESCRIPTION
Adds documentation for experimental mode to the README, including:

- How to activate experimental mode (`--experimental` flag or `/experimental` slash command)
- Note that the setting persists in config after activation
- Experimental features subsection with autopilot mode documentation