### PR TITLE
Add PowerShell dependency to winget manifests

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -44,8 +44,12 @@ jobs:
             --out manifests
           
           # Add PowerShell dependency to installer manifest
-          $installerManifest = Get-ChildItem -Path manifests -Filter "*.installer.yaml" -Recurse | Select-Object -First 1
-          $content = Get-Content $installerManifest -Raw
+          $installerManifest = Get-ChildItem -Path manifests -Filter "*.installer.yaml" -Recurse | Select-Object -First 1 -ExpandProperty FullName
+          if (-not $installerManifest) {
+            Write-Error "No installer manifest (*.installer.yaml) was found in the 'manifests' directory."
+            exit 1
+          }
+          $content = Get-Content -Path $installerManifest -Raw
           $dependency = @"
 Dependencies:
   PackageDependencies:
@@ -54,7 +58,7 @@ Dependencies:
 "@
           # Insert dependency block before the Installers section
           $content = $content -replace '(?m)^Installers:', "$dependency`nInstallers:"
-          Set-Content -Path $installerManifest -Value $content -NoNewline
+          Set-Content -Path $installerManifest -Value $content
           
           # Submit the modified manifest
           .\wingetcreate.exe submit manifests


### PR DESCRIPTION
This PR modifies the winget workflow to inject a PowerShell >= 7.0.0 package dependency into the installer manifest before submission.

## Changes
- Output manifests to a directory instead of submitting directly
- Insert `Dependencies.PackageDependencies` block with `Microsoft.PowerShell >= 7.0.0` into the installer YAML
- Submit the modified manifest

This ensures users installing via `winget install GitHub.Copilot` or `winget install GitHub.Copilot.Prerelease` will have PowerShell 7+ as a dependency.

Reference: https://github.com/microsoft/winget-pkgs/pull/335848. Note that this didn't work because it only affected a single version. I had been under the impression that extra manifest content was preserved across versions but they were not. Seems we have to change the manifest before we submit it.