### PR TITLE
Add PowerShell dependency to winget manifests

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -41,4 +41,24 @@ jobs:
           .\wingetcreate.exe update $packageId `
             --version $packageVersion `
             --urls "$installerUrlx64|x64" "$installerUrlarm64|arm64" `
-            --submit
+            --out manifests
+
+          # Add PowerShell dependency to installer manifest
+          $installerManifest = Get-ChildItem -Path manifests -Filter "*.installer.yaml" -Recurse | Select-Object -First 1 -ExpandProperty FullName
+          if (-not $installerManifest) {
+            Write-Error "No installer manifest (*.installer.yaml) was found in the 'manifests' directory."
+            exit 1
+          }
+          $content = Get-Content -Path $installerManifest -Raw
+          $dependency = @"
+          Dependencies:
+            PackageDependencies:
+              - PackageIdentifier: Microsoft.PowerShell
+                MinimumVersion: "7.0.0"
+          "@
+          # Insert dependency block before the Installers section
+          $content = $content -replace '(?m)^Installers:', "$dependency`nInstallers:"
+          Set-Content -Path $installerManifest -Value $content
+
+          # Submit the modified manifest
+          .\wingetcreate.exe submit manifests


### PR DESCRIPTION
Re-applies the change from PR #1497 which was reverted in PR #1548.

## What changed

The winget workflow now modifies the installer manifest to declare a dependency on PowerShell 7+ before submitting to the WinGet community repository.

## What went wrong last time

The original PR's PowerShell here-string content and closing `"@` had **zero indentation** inside the YAML `run: |` block. YAML literal block scalars require all content lines to be indented at least as much as the first content line (10 spaces here). The unindented lines terminated the block scalar, causing the workflow YAML to fail validation — the run had 0 jobs and never started.

## Fix

Indent the here-string body and closing `"@` to match the surrounding YAML block indentation. YAML strips those leading spaces during parsing, producing valid PowerShell with `"@` at column 0 as required.
