### PR TITLE
Include PowerShell dependency in winget manifest (v3)

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -56,9 +56,11 @@ jobs:
               - PackageIdentifier: Microsoft.PowerShell
                 MinimumVersion: "7.0.0"
           "@
-          # Insert dependency block before the Installers section
+          # Remove existing top-level Dependencies block (if any), then insert ours
+          $content = $content -replace '(?m)^Dependencies:\r?\n([ ]+.+\r?\n)*', ''
           $content = $content -replace '(?m)^Installers:', "$dependency`nInstallers:"
           Set-Content -Path $installerManifest -Value $content
 
           # Submit the modified manifest
-          .\wingetcreate.exe submit manifests
+          $manifestPath = Split-Path $installerManifest
+          .\wingetcreate.exe submit $manifestPath


### PR DESCRIPTION
Fixes two issues in the previous iteration:

 * Passes the correct directory path to `wingetcreate.exe submit`, fixing the *Subdirectory not supported in manifest path* error
 * Handles the situation where a prior version of the manifest already declares the dependency. It now overwrites any existing list of dependencies using the information from our workflow here, so this workflow is the source of truth

This time I actually ran the logic manually even to the point of letting it submit [a PR which I then closed](https://github.com/microsoft/winget-pkgs/pull/341104).