### PR TITLE
Update instructions for adding permissions in PAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ If you're not currently logged in to GitHub, you'll be prompted to use the `/log
 You can also authenticate using a fine-grained PAT with the "Copilot Requests" permission enabled.
 
 1. Visit https://github.com/settings/personal-access-tokens/new
-2. Under "Permissions," click "add permissions" and select "Copilot Requests"
+2. Under "Permissions", click "Account", click "Add permissions", and select "Copilot Requests"
 3. Generate your token
 4. Add the token to your environment via the environment variable `GH_TOKEN` or `GITHUB_TOKEN` (in order of precedence)
 


### PR DESCRIPTION
The `Copilot Requests` permission is under the Account tab in the PAT permissions UI, which is easy to miss. This updates the instructions to clarify the exact navigation path.