### PR TITLE
install: guide user to update PATH for current shell session

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -156,6 +156,7 @@ if ! command -v copilot >/dev/null 2>&1; then
       if [ "$REPLY" = "y" ] || [ "$REPLY" = "Y" ]; then
         echo "export PATH=\"$INSTALL_DIR:\$PATH\"" >> "$RC_FILE"
         echo "✓ Added PATH export to $RC_FILE"
+        echo "  Restart your shell or run: source $RC_FILE"
       fi
     fi
   else
@@ -163,7 +164,11 @@ if ! command -v copilot >/dev/null 2>&1; then
     echo "To add $INSTALL_DIR to your PATH permanently, add this to $RC_FILE:"
     echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
   fi
-fi
 
-echo ""
-echo "Installation complete! Run 'copilot help' to get started."
+  echo ""
+  echo "Installation complete! To get started, run:"
+  echo "  export PATH=\"$INSTALL_DIR:\$PATH\" && copilot help"
+else
+  echo ""
+  echo "Installation complete! Run 'copilot help' to get started."
+fi


### PR DESCRIPTION
After running `curl -fsSL https://gh.io/copilot-install | bash`, the installed `copilot` binary may not be on PATH for the current shell session. The script already detects this and offers to add a PATH export to the user's RC file, but doesn't help with the **current** session.

### Changes

- When the user accepts adding PATH to their RC file, print a hint to restart their shell or `source` the file
- Replace the final `Run 'copilot help'` message (which would fail if not on PATH) with a copy-pasteable one-liner: `export PATH="..." && copilot help`
- Keep the simple `copilot help` message when the binary is already on PATH