### PR TITLE
install: retry without token when authenticated requests fail

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,6 +44,31 @@ if [ -n "$GITHUB_TOKEN" ]; then
   GIT_REMOTE="https://x-access-token:${GITHUB_TOKEN}@github.com/github/copilot-cli"
 fi
 
+# Download a file, retrying without auth on failure (e.g. SAML enforcement)
+download() {
+  local url="$1" output="$2"
+  if command -v curl >/dev/null 2>&1; then
+    if [ ${#CURL_AUTH[@]} -gt 0 ]; then
+      if curl -fsSL "${CURL_AUTH[@]}" "$url" -o "$output" 2>/dev/null; then
+        return 0
+      fi
+      echo "Warning: Authenticated request failed, retrying without token..." >&2
+    fi
+    curl -fsSL "$url" -o "$output"
+  elif command -v wget >/dev/null 2>&1; then
+    if [ ${#WGET_AUTH[@]} -gt 0 ]; then
+      if wget -qO "$output" "${WGET_AUTH[@]}" "$url" 2>/dev/null; then
+        return 0
+      fi
+      echo "Warning: Authenticated request failed, retrying without token..." >&2
+    fi
+    wget -qO "$output" "$url"
+  else
+    echo "Error: Neither curl nor wget found. Please install one of them." >&2
+    return 1
+  fi
+}
+
 # Determine download URL based on VERSION
 if [ "${VERSION}" = "latest" ] || [ -z "$VERSION" ]; then
   DOWNLOAD_URL="https://github.com/github/copilot-cli/releases/latest/download/copilot-${PLATFORM}-${ARCH}.tar.gz"
@@ -54,7 +79,11 @@ elif [ "${VERSION}" = "prerelease" ]; then
     echo "Error: git is required to install prerelease versions" >&2
     exit 1
   fi
-  VERSION="$(git ls-remote --tags "$GIT_REMOTE" | tail -1 | awk -F/ '{print $NF}')"
+  VERSION="$(git ls-remote --tags "$GIT_REMOTE" 2>/dev/null | tail -1 | awk -F/ '{print $NF}')"
+  if [ -z "$VERSION" ] && [ "$GIT_REMOTE" != "https://github.com/github/copilot-cli" ]; then
+    echo "Warning: Authenticated git request failed, retrying without token..."
+    VERSION="$(git ls-remote --tags https://github.com/github/copilot-cli | tail -1 | awk -F/ '{print $NF}')"
+  fi
   if [ -z "$VERSION" ]; then
     echo "Error: Could not determine prerelease version" >&2
     exit 1
@@ -76,12 +105,7 @@ echo "Downloading from: $DOWNLOAD_URL"
 # Download and extract with error handling
 TMP_DIR="$(mktemp -d)"
 TMP_TARBALL="$TMP_DIR/copilot-${PLATFORM}-${ARCH}.tar.gz"
-if command -v curl >/dev/null 2>&1; then
-  curl -fsSL "${CURL_AUTH[@]}" "$DOWNLOAD_URL" -o "$TMP_TARBALL"
-elif command -v wget >/dev/null 2>&1; then
-  wget -qO "$TMP_TARBALL" "${WGET_AUTH[@]}" "$DOWNLOAD_URL"
-else
-  echo "Error: Neither curl nor wget found. Please install one of them."
+if ! download "$DOWNLOAD_URL" "$TMP_TARBALL"; then
   rm -rf "$TMP_DIR"
   exit 1
 fi
@@ -89,10 +113,8 @@ fi
 # Attempt to download checksums file and validate
 TMP_CHECKSUMS="$TMP_DIR/SHA256SUMS.txt"
 CHECKSUMS_AVAILABLE=false
-if command -v curl >/dev/null 2>&1; then
-  curl -fsSL "${CURL_AUTH[@]}" "$CHECKSUMS_URL" -o "$TMP_CHECKSUMS" 2>/dev/null && CHECKSUMS_AVAILABLE=true
-elif command -v wget >/dev/null 2>&1; then
-  wget -qO "$TMP_CHECKSUMS" "${WGET_AUTH[@]}" "$CHECKSUMS_URL" 2>/dev/null && CHECKSUMS_AVAILABLE=true
+if download "$CHECKSUMS_URL" "$TMP_CHECKSUMS" 2>/dev/null; then
+  CHECKSUMS_AVAILABLE=true
 fi
 
 if [ "$CHECKSUMS_AVAILABLE" = true ]; then


### PR DESCRIPTION
## Summary

When a `GITHUB_TOKEN` is set but belongs to a GitHub org member whose token hasn't been SSO-authorized, SAML enforcement rejects the request — causing the install to fail even though the repo is public.

This adds a `download()` helper that tries with the token first, then automatically retries without it on failure. The same retry logic is applied to the `git ls-remote` call used for prerelease version detection.

## Changes

- Added `download()` helper function that:
  1. Attempts the request with the auth token (stderr suppressed)
  2. On failure, prints a warning and retries without the token
  3. Reports `curl`/`wget` not found if neither is available
- Replaced inline `curl`/`wget` calls for tarball and checksums downloads with `download()`
- Added retry-without-auth fallback to `git ls-remote` for prerelease detection

## Behavior

| Scenario | Result |
|---|---|
| No `GITHUB_TOKEN` set | Unauthenticated request (no change) |
| Valid token | Authenticated request succeeds on first try |
| Token rejected (SAML/SSO) | Warning printed, unauthenticated retry succeeds |
| Token rejected + repo actually private | Warning printed, unauthenticated retry also fails → error |