### PR TITLE
Alter PATH for login shells, not interactive shells

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -153,7 +153,7 @@ if ! command -v copilot >/dev/null 2>&1; then
 
   # Detect shell profile file for PATH
   case "$(basename "${SHELL:-/bin/sh}")" in
-    zsh) RC_FILE="$HOME/.zprofile" ;;
+    zsh) RC_FILE="${ZDOTDIR:-$HOME}/.zprofile" ;;
     bash)
       if [ -f "$HOME/.bash_profile" ]; then
         RC_FILE="$HOME/.bash_profile"


### PR DESCRIPTION
- Resolves https://github.com/github/copilot-cli/issues/2001

Can confirm the recommendation there is correct, and furthermore altering `.bashrc` causes duplicate PATH entries when nesting interactive shells.