### PR TITLE
Sort git tags when determining prerelease version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,7 @@ elif [ "${VERSION}" = "prerelease" ]; then
     echo "Error: git is required to install prerelease versions" >&2
     exit 1
   fi
-  VERSION="$(git ls-remote --tags "$GIT_REMOTE" | tail -1 | awk -F/ '{print $NF}')"
+  VERSION="$(git ls-remote --tags --sort "version:refname" "$GIT_REMOTE" | tail -1 | awk -F/ '{print $NF}')"
   if [ -z "$VERSION" ]; then
     echo "Error: Could not determine prerelease version" >&2
     exit 1


### PR DESCRIPTION
Hello! I hope you're having a nice day. :)

Tags are sorted lexicographically by default, not by version, so for example right now `git ls-remote` for this repo shows:

```shell
$ git ls-remote --tags \
  https://github.com/github/copilot-cli \
  | tail -3 | awk -F/ '{print$NF}'
v1.0.8
v1.0.8-0
v1.0.9
```

With the [sort option](https://git-scm.com/docs/git-ls-remote#Documentation/git-ls-remote.txt---sortkey), it shows the correct latest prerelease tags:

```shell
$ git ls-remote --tags --sort "version:refname" \
  https://github.com/github/copilot-cli \
  | tail -3 | awk -F/ '{print$NF}'
v1.0.12-0
v1.0.12-1
v1.0.12-2
```

This option for `git ls-remote` was added in git version 2.18.0 in June 2018:
https://github.com/git/git/blob/v2.18.0/Documentation/RelNotes/2.18.0.txt#L69-L70
so I would hope it's pretty well established out there at this point.

---

I noticed there's an open issue for `npm install` prerelease -- #2327 -- but the numbers there don't seem to line up with what I'm seeing, so might be completely unrelated. For what it's worth, at this time that installation method is getting the latest _non_-prerelease, as though `@prerelease` is being ignored entirely, rather than getting a bad sort like this.