### PR TITLE
install: use EXIT trap for temp directory cleanup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -75,6 +75,7 @@ echo "Downloading from: $DOWNLOAD_URL"
 
 # Download and extract with error handling
 TMP_DIR="$(mktemp -d)"
+trap 'rm -rf -- "$TMP_DIR"' EXIT
 TMP_TARBALL="$TMP_DIR/copilot-${PLATFORM}-${ARCH}.tar.gz"
 if command -v curl >/dev/null 2>&1; then
   curl -fsSL "${CURL_AUTH[@]}" "$DOWNLOAD_URL" -o "$TMP_TARBALL"
@@ -82,7 +83,6 @@ elif command -v wget >/dev/null 2>&1; then
   wget -qO "$TMP_TARBALL" "${WGET_AUTH[@]}" "$DOWNLOAD_URL"
 else
   echo "Error: Neither curl nor wget found. Please install one of them."
-  rm -rf "$TMP_DIR"
   exit 1
 fi
 
@@ -101,7 +101,6 @@ if [ "$CHECKSUMS_AVAILABLE" = true ]; then
       echo "✓ Checksum validated"
     else
       echo "Error: Checksum validation failed." >&2
-      rm -rf "$TMP_DIR"
       exit 1
     fi
   elif command -v shasum >/dev/null 2>&1; then
@@ -109,7 +108,6 @@ if [ "$CHECKSUMS_AVAILABLE" = true ]; then
       echo "✓ Checksum validated"
     else
       echo "Error: Checksum validation failed." >&2
-      rm -rf "$TMP_DIR"
       exit 1
     fi
   else
@@ -120,7 +118,6 @@ fi
 # Check that the file is a valid tarball
 if ! tar -tzf "$TMP_TARBALL" >/dev/null 2>&1; then
   echo "Error: Downloaded file is not a valid tarball or is corrupted." >&2
-  rm -rf "$TMP_DIR"
   exit 1
 fi
 
@@ -144,7 +141,6 @@ fi
 tar -xz -C "$INSTALL_DIR" -f "$TMP_TARBALL"
 chmod +x "$INSTALL_DIR/copilot"
 echo "✓ GitHub Copilot CLI installed to $INSTALL_DIR/copilot"
-rm -rf "$TMP_DIR"
 
 # Check if installed binary is accessible
 if ! command -v copilot >/dev/null 2>&1; then


### PR DESCRIPTION
The install script creates a temp directory with `mktemp -d` but relies on manual `rm -rf` calls scattered across individual error handlers to clean it up. Several exit paths are missing cleanup entirely:

- `curl`/`wget` download failure (`set -e` exits before any cleanup)
- `tar` extraction failure
- `chmod` failure
- `mkdir -p` failure (handled error path, but no `rm -rf`)

This replaces all five manual `rm -rf "$TMP_DIR"` calls with a single `trap ... EXIT` registered immediately after the temp directory is created. The trap fires on any exit—whether from `set -e`, an explicit `exit 1`, or normal completion—so every path is covered with one line.

**Before:** 5 cleanup calls, 4+ uncovered exit paths
**After:** 1 trap, 0 uncovered exit paths