### PR TITLE
install: add fish shell support for PATH configuration

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -152,7 +152,8 @@ if ! command -v copilot >/dev/null 2>&1; then
   echo "Notice: $INSTALL_DIR is not in your PATH"
 
   # Detect shell profile file for PATH
-  case "$(basename "${SHELL:-/bin/sh}")" in
+  CURRENT_SHELL="$(basename "${SHELL:-/bin/sh}")"
+  case "$CURRENT_SHELL" in
     zsh) RC_FILE="${ZDOTDIR:-$HOME}/.zprofile" ;;
     bash)
       if [ -f "$HOME/.bash_profile" ]; then
@@ -163,8 +164,14 @@ if ! command -v copilot >/dev/null 2>&1; then
         RC_FILE="$HOME/.profile"
       fi
       ;;
+    fish) RC_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/fish/conf.d/copilot.fish" ;;
     *) RC_FILE="$HOME/.profile" ;;
   esac
+
+  PATH_LINE="export PATH=\"$INSTALL_DIR:\$PATH\""
+  if [ "$CURRENT_SHELL" = "fish" ]; then
+    PATH_LINE="fish_add_path \"$INSTALL_DIR\""
+  fi
 
   # Prompt user to add to shell rc file (only if interactive)
   if [ -t 0 ] || [ -e /dev/tty ]; then
@@ -172,20 +179,21 @@ if ! command -v copilot >/dev/null 2>&1; then
     printf "Would you like to add it to %s? [y/N] " "$RC_FILE"
     if read -r REPLY </dev/tty 2>/dev/null; then
       if [ "$REPLY" = "y" ] || [ "$REPLY" = "Y" ]; then
-        echo "export PATH=\"$INSTALL_DIR:\$PATH\"" >> "$RC_FILE"
-        echo "✓ Added PATH export to $RC_FILE"
+        mkdir -p "$(dirname "$RC_FILE")"
+        echo "$PATH_LINE" >> "$RC_FILE"
+        echo "✓ Added PATH configuration to $RC_FILE"
         echo "  Restart your shell or run: source $RC_FILE"
       fi
     fi
   else
     echo ""
     echo "To add $INSTALL_DIR to your PATH permanently, add this to $RC_FILE:"
-    echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
+    echo "  $PATH_LINE"
   fi
 
   echo ""
   echo "Installation complete! To get started, run:"
-  echo "  export PATH=\"$INSTALL_DIR:\$PATH\" && copilot help"
+  echo "  $PATH_LINE && copilot help"
 else
   echo ""
   echo "Installation complete! Run 'copilot help' to get started."


### PR DESCRIPTION
Fish shell users currently fall into the catch-all `*)` case in the shell profile detection, which writes POSIX `export` syntax to `~/.profile`. This silently does nothing because:

1. Fish does not source `~/.profile`
2. Fish does not use `export PATH="...:$PATH"` syntax (PATH is an array in fish, not colon-separated)
3. The get-started hint `export PATH="..." && copilot help` fails in a fish session

This adds a `fish)` case alongside the existing `zsh)` and `bash)` cases, using the idiomatic config path and command:

- **Config file:** `${XDG_CONFIG_HOME:-$HOME/.config}/fish/conf.d/copilot.fish` (auto-sourced by fish)
- **PATH command:** `fish_add_path` (available since fish 3.2, released March 2021)

The three places that previously hardcoded `export PATH=...` now use a `PATH_LINE` variable, so the shell-specific logic lives in one place rather than being duplicated across the interactive prompt, non-interactive hint, and get-started instructions.

**Before (fish user):**
```
Would you like to add it to /home/user/.profile? [y/N] y
✓ Added PATH export to /home/user/.profile    ← fish never reads this
  export PATH="/home/user/.local/bin:$PATH" && copilot help    ← fails in fish
```

**After (fish user):**
```
Would you like to add it to /home/user/.config/fish/conf.d/copilot.fish? [y/N] y
✓ Added PATH export to /home/user/.config/fish/conf.d/copilot.fish
  fish_add_path "/home/user/.local/bin" && copilot help
```

No change in behavior for bash, zsh, or other POSIX shells.