### PR TITLE
install: guard against duplicate PATH entries on reinstall

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -175,9 +175,13 @@ if ! command -v copilot >/dev/null 2>&1; then
     printf "Would you like to add it to %s? [y/N] " "$RC_FILE"
     if read -r REPLY </dev/tty 2>/dev/null; then
       if [ "$REPLY" = "y" ] || [ "$REPLY" = "Y" ]; then
-        mkdir -p "$(dirname "$RC_FILE")"
-        echo "$PATH_LINE" >> "$RC_FILE"
-        echo "✓ Added PATH configuration to $RC_FILE"
+        if grep -qxF -- "$PATH_LINE" "$RC_FILE" 2>/dev/null; then
+          echo "✓ PATH configuration already in $RC_FILE"
+        elif mkdir -p "$(dirname "$RC_FILE")" && echo "$PATH_LINE" >> "$RC_FILE"; then
+          echo "✓ Added PATH configuration to $RC_FILE"
+        else
+          echo "✗ Failed to update $RC_FILE (check permissions)" >&2
+        fi
         echo "  Restart your shell or run: source $RC_FILE"
       fi
     fi


### PR DESCRIPTION
Running the installer twice without restarting the shell causes the PATH configuration line to be appended to the shell profile a second time. This happens because the script checks `command -v copilot` to decide whether to prompt for PATH setup, but that check requires a shell restart to reflect the previous install's RC_FILE changes.

**Repro:**
```bash
curl -fsSL https://gh.io/copilot-install | bash   # say y to PATH prompt
curl -fsSL https://gh.io/copilot-install | bash   # say y again → duplicate line
```

**Result:** `~/.bash_profile` (or equivalent) contains the same `export PATH=...` line twice.

This adds a `grep -qF` check for the exact `PATH_LINE` in `RC_FILE` before appending, making the write idempotent. On reinstall, the script reports that the configuration is already present instead of duplicating it.

**Before (reinstall):**
```
✓ Added PATH configuration to /home/user/.bash_profile   ← duplicate appended
```

**After (reinstall):**
```
✓ PATH configuration already in /home/user/.bash_profile
```

Works for all shells (bash, zsh, fish, POSIX fallback) since it matches the exact `PATH_LINE` string.