### PR TITLE
Change Feature Request template input type from 'input' to 'textarea'

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,7 @@ body:
       value: |
         <br />
         Thank you for taking the time to suggest a feature! Please answer each question below to the best of your ability; it is okay to leave questions blank if you have to.
-  - type: input
+  - type: textarea
     id: title
     attributes:
       label: Describe the feature or problem you'd like to solve


### PR DESCRIPTION
The current template makes it difficult to properly describe feature requests. Problem statements often require multiple sentences, examples, or code snippets, but the existing single-line input fields force users into overly constrained responses.

<img width="1165" height="600" alt="image" src="https://github.com/user-attachments/assets/cdc5d882-1ed4-4353-85d6-305c6cafb207" />


If anything, the current template is backwards. In practice, describing a problem usually takes more space and context, while a proposed solution can often be summarized in a sentence or two—but the current input fields impose the opposite constraint. 

However, in the spirit of eliminating unnecessary constraints, this PR opts to simply allow all fields to be `textarea`s.