### PR TITLE
Update Homebrew installation commands for copilot-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ curl -fsSL https://gh.io/copilot-install | VERSION="v0.0.369" PREFIX="$HOME/cust
 Install with [Homebrew](https://formulae.brew.sh/cask/copilot-cli) (macOS and Linux):
 
 ```bash
-brew install copilot-cli
+brew install --cask copilot-cli
 ```
 
 ```bash
-brew install copilot-cli@prerelease
+brew install --cask copilot-cli@prerelease
 ```
 
 


### PR DESCRIPTION
It seems as if the CLI tools were moved:

https://formulae.brew.sh/cask/copilot-cli
https://formulae.brew.sh/cask/copilot-cli@prerelease