### PR TITLE
install: report unsupported operating systems

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ echo "Installing GitHub Copilot CLI..."
 case "$(uname -s || echo "")" in
   Darwin*) PLATFORM="darwin" ;;
   Linux*) PLATFORM="linux" ;;
-  *)
+  CYGWIN*|MINGW*|MSYS*)
     if command -v winget >/dev/null 2>&1; then
       echo "Windows detected. Installing via winget..."
       winget install GitHub.Copilot
@@ -25,6 +25,7 @@ case "$(uname -s || echo "")" in
       exit 1
     fi
     ;;
+  *) echo "Error: Unsupported operating system $(uname -s)" >&2 ; exit 1 ;;
 esac
 
 # Detect architecture


### PR DESCRIPTION
## Why

On FreeBSD, `install.sh` reports `Windows detected but winget not found` because every operating system other than macOS and Linux falls into the Windows branch. Copilot CLI does not publish a FreeBSD binary, so the installer should report the platform as unsupported.

## What changed

The installer now treats Cygwin, MinGW, and MSYS as Windows. Other unknown systems fail with their actual `uname -s` value.

## References

https://github.com/github/copilot-cli/issues/3710

## Testing

| Scenario | Result |
| --- | --- |
| FreeBSD against `upstream/main` | Reproduced the incorrect Windows message |
| FreeBSD with this change | Reports `Unsupported operating system FreeBSD` |
| MinGW | Still invokes `winget install GitHub.Copilot` |
| macOS arm64 and Linux x64 | Still select their existing release assets |

<details>
<summary>Raw logs</summary>

```console
$ tmp=$(mktemp -d)
$ printf '#!/bin/sh\ncase "$1" in -m) echo amd64;; *) echo FreeBSD;; esac\n' > "$tmp/uname"
$ chmod +x "$tmp/uname"
$ git show upstream/main:install.sh > "$tmp/before.sh"
$ PATH="$tmp:/usr/bin:/bin" bash "$tmp/before.sh"; echo "exit=$?"
Installing GitHub Copilot CLI...
Error: Windows detected but winget not found. Please see https://gh.io/install-copilot-readme
exit=1

$ PATH="$tmp:/usr/bin:/bin" bash install.sh; echo "exit=$?"
Installing GitHub Copilot CLI...
Error: Unsupported operating system FreeBSD
exit=1
```

</details>

`bash -n install.sh` and `git diff --check` pass.
