### PR TITLE
install: report unsupported operating systems

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ echo "Installing GitHub Copilot CLI..."
 case "$(uname -s || echo "")" in
   Darwin*) PLATFORM="darwin" ;;
   Linux*) PLATFORM="linux" ;;
-  *)
+  CYGWIN*|MINGW*|MSYS*)
     if command -v winget >/dev/null 2>&1; then
       echo "Windows detected. Installing via winget..."
       winget install GitHub.Copilot
@@ -25,6 +25,7 @@ case "$(uname -s || echo "")" in
       exit 1
     fi
     ;;
+  *) echo "Error: Unsupported operating system $(uname -s)" >&2 ; exit 1 ;;
 esac
 
 # Detect architecture

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,8 @@ set -e
 echo "Installing GitHub Copilot CLI..."
 
 # Detect platform
-case "$(uname -s || echo "")" in
+OS="$(uname -s || echo "")"
+case "$OS" in
   Darwin*) PLATFORM="darwin" ;;
   Linux*) PLATFORM="linux" ;;
   CYGWIN*|MINGW*|MSYS*)
@@ -25,7 +26,7 @@ case "$(uname -s || echo "")" in
       exit 1
     fi
     ;;
-  *) echo "Error: Unsupported operating system $(uname -s)" >&2 ; exit 1 ;;
+  *) echo "Error: Unsupported operating system $OS" >&2 ; exit 1 ;;
 esac
 
 # Detect architecture


### PR DESCRIPTION
## Why

On FreeBSD, `install.sh` reports `Windows detected but winget not found` because every operating system other than macOS and Linux falls into the Windows branch. Copilot CLI does not publish a FreeBSD binary, so the installer should report the platform as unsupported.

## What changed

- Match Cygwin, MinGW, and MSYS explicitly as Windows environments.
- Reject unknown systems with their actual `uname -s` value.

Fixes #3710.

## Testing

- `bash -n install.sh`
- `git diff --check`
- Simulated FreeBSD and OpenBSD; both return an unsupported operating system error.
- Simulated Cygwin, MinGW, and MSYS; all still invoke `winget install GitHub.Copilot`.